### PR TITLE
Added a Dockerfile and a .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# Ignore git dir
+.git
+# Ingore flake files
+.flake*
+# Ignore the keys directory
+keys
+
+Dockerfile
+db.sqlite3
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.Python
+env
+pip-log.txt
+pip-delete-this-directory.txt
+.tox
+.coverage
+.coverage.*
+.cache
+coverage.xml
+*,cover
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.7.1-slim-stretch
+
+WORKDIR /app/magicproxy
+
+COPY . .
+
+RUN pip install -r requirements.txt
+RUN python setup.py install
+
+CMD ["python3"]
+


### PR DESCRIPTION
This takes inspiration from the grpc Docker images where there is a base image
that contains the magixproxy package installed, and provides the
standard "python3" entrypoint. This way consumers of magicproxy can
declare

FROM magicproxy:latest

and have an environment with magicproxy preinstalled

Change-Id: I7641cbc5cc6c94db02f796bb174c0addda487e8c