### PR TITLE
Changed location of key files to be set via an environment variable

### DIFF
--- a/src/magicproxy/__main__.py
+++ b/src/magicproxy/__main__.py
@@ -15,4 +15,4 @@
 from magicproxy import proxy
 
 if __name__ == "__main__":
-    proxy.app.run(debug=True)
+    proxy.run_app()

--- a/src/magicproxy/async_proxy.py
+++ b/src/magicproxy/async_proxy.py
@@ -15,11 +15,12 @@
 import aiohttp
 import aiohttp.web
 
+import os
+
 from . import magictoken
 from . import scopes
 
 GITHUB_API_ROOT = "https://api.github.com"
-KEYS = magictoken.Keys.from_files("keys/private.pem", "keys/public.x509.cer")
 
 routes = aiohttp.web.RouteTableDef()
 
@@ -118,6 +119,10 @@ async def proxy_api(request):
 
 
 async def build_app(argv):
+    private_key_location = os.environ['MAGICPROXY_PRIVATE_KEY']
+    public_key_location = os.environ['MAGICPROXY_PUBLIC_KEY']
+    KEYS = magictoken.Keys.from_files(private_key_location, public_key_location)
+
     app = aiohttp.web.Application()
     app.add_routes(routes)
     return app

--- a/src/magicproxy/async_proxy.py
+++ b/src/magicproxy/async_proxy.py
@@ -35,7 +35,7 @@ async def create_magic_token(request):
     if not isinstance(params.get("scopes"), list):
         raise aiohttp.web.HTTPInvalidRequest("Scopes must be a list.")
 
-    token = magictoken.create(KEYS, params["github_token"], params["scopes"])
+    token = magictoken.create(keys, params["github_token"], params["scopes"])
 
     return aiohttp.web.Response(body=token, headers={"Content-Type": "application/jwt"})
 
@@ -103,7 +103,7 @@ async def proxy_api(request):
         auth_token = auth_token[len("Bearer ") :]
 
     # Validate the magic token
-    token_info = magictoken.decode(KEYS, auth_token)
+    token_info = magictoken.decode(keys, auth_token)
 
     # Validate scopes againt URL and method.
     if not scopes.validate_request(request.method, request.path, token_info.scopes):
@@ -119,9 +119,7 @@ async def proxy_api(request):
 
 
 async def build_app(argv):
-    private_key_location = os.environ['MAGICPROXY_PRIVATE_KEY']
-    public_key_location = os.environ['MAGICPROXY_PUBLIC_KEY']
-    KEYS = magictoken.Keys.from_files(private_key_location, public_key_location)
+    keys = magictoken.Keys.from_env()
 
     app = aiohttp.web.Application()
     app.add_routes(routes)

--- a/src/magicproxy/magictoken.py
+++ b/src/magicproxy/magictoken.py
@@ -15,6 +15,7 @@
 import base64
 import calendar
 import datetime
+import os
 from typing import List
 
 import attr
@@ -86,6 +87,12 @@ class Keys:
             certificate=certificate,
             certificate_pem=certificate_pem,
         )
+
+    @classmethod
+    def from_env(cls):
+        private_key_location = os.environ['MAGICPROXY_PRIVATE_KEY']
+        public_key_location = os.environ['MAGICPROXY_PUBLIC_KEY']
+        return Keys.from_files(private_key_location, public_key_location)
 
 
 def create(keys: Keys, github_token, scopes) -> str:

--- a/src/magicproxy/proxy.py
+++ b/src/magicproxy/proxy.py
@@ -21,7 +21,6 @@ from . import magictoken
 from . import scopes
 
 GITHUB_API_ROOT = "https://api.github.com"
-KEYS = magictoken.Keys.from_files("keys/private.pem", "keys/public.x509.cer")
 
 app = flask.Flask(__name__)
 
@@ -111,6 +110,12 @@ def proxy_api(path):
         headers={"Authorization": f"Bearer {token_info.github_token}"},
     )
 
+def run_app():
+    private_key_location = os.environ['MAGICPROXY_PRIVATE_KEY']
+    public_key_location = os.environ['MAGICPROXY_PUBLIC_KEY']
+    KEYS = magictoken.Keys.from_files(private_key_location, public_key_location)
+
+    app.run()
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    run_app()

--- a/src/magicproxy/proxy.py
+++ b/src/magicproxy/proxy.py
@@ -35,7 +35,7 @@ def create_magic_token():
     if not isinstance(params.get("scopes"), list):
         return "scopes must be a list", 400
 
-    token = magictoken.create(KEYS, params["github_token"], params["scopes"])
+    token = magictoken.create(keys, params["github_token"], params["scopes"])
 
     return token, 200, {"Content-Type": "application/jwt"}
 
@@ -95,7 +95,7 @@ def proxy_api(path):
         auth_token = auth_token[len("Bearer ") :]
 
     # Validate the magic token
-    token_info = magictoken.decode(KEYS, auth_token)
+    token_info = magictoken.decode(keys, auth_token)
 
     # Validate scopes against URL and method.
     if not scopes.validate_request(flask.request.method, path, token_info.scopes):
@@ -111,10 +111,7 @@ def proxy_api(path):
     )
 
 def run_app():
-    private_key_location = os.environ['MAGICPROXY_PRIVATE_KEY']
-    public_key_location = os.environ['MAGICPROXY_PUBLIC_KEY']
-    KEYS = magictoken.Keys.from_files(private_key_location, public_key_location)
-
+    keys = magictoken.Keys.from_env()
     app.run()
 
 if __name__ == "__main__":

--- a/tests/test_magictoken.py
+++ b/tests/test_magictoken.py
@@ -37,3 +37,21 @@ def test_create_and_decode():
 
     assert decoded.github_token == github_token
     assert scopes == scopes
+
+def test_get_from_env_and_decode():
+    os.environ['MAGICPROXY_PRIVATE_KEY'] = os.path.join(DATA, 'private.pem')
+    os.environ['MAGICPROXY_PUBLIC_KEY'] = os.path.join(DATA, 'public.x509.cer')
+    local_keys = magictoken.Keys.from_env()
+
+    github_token = "this is a token"
+    scopes = ["a", "b", "c"]
+
+    result = magictoken.create(local_keys, github_token, scopes)
+
+    # Make sure that the github token does not appear in plaintext
+    assert github_token not in result
+
+    decoded = magictoken.decode(local_keys, result)
+
+    assert decoded.github_token == github_token
+    assert scopes == scopes


### PR DESCRIPTION
This permits tests to load without having keys stored/generated
This also permits for users of magicproxy to specify the key location on
their own.

This change also adds a run_app() function to proxy.py similar in nature
to the build_app() function in async_proxy.py

Change-Id: Ia41105c4fdad8f3f49c84b38e4e886ca9552e8e7
Signed-off-by: Colin Nelson <colnnelson@google.com>