### PR TITLE
Clean headers

### DIFF
--- a/src/magicproxy/async_proxy.py
+++ b/src/magicproxy/async_proxy.py
@@ -23,6 +23,8 @@ KEYS = magictoken.Keys.from_files("keys/private.pem", "keys/public.x509.cer")
 
 routes = aiohttp.web.RouteTableDef()
 
+_query_params_to_clean = set()
+_custom_request_headers_to_clean = set()
 
 @routes.post("/magictoken")
 async def create_magic_token(request):
@@ -45,6 +47,7 @@ def _clean_request_headers(headers):
     headers.pop("Connection", None)
     # Drop the existing authorization header, it'll only cause problems.
     headers.pop("Authorization", None)
+    headers = _clean_custom_request_headers(headers)
     return headers
 
 
@@ -110,12 +113,35 @@ async def proxy_api(request):
             f"Disallowed by GitHub proxy. Allowed scopes: {', '.join(token_info.scopes)}"
         )
 
+    path = _clean_path_queries(path)
+
     return await _proxy_request(
         request=request,
         url=f"{GITHUB_API_ROOT}/{path}",
         headers={"Authorization": f"Bearer {token_info.github_token}"},
     )
 
+def _clean_path_queries(path) -> str:
+    for param in _query_params_to_clean:
+        path, replaced = re.subn('({}=[\w*-+.%]*)(?:$|\&)'.format(param),'',path)
+    return path
+
+def queries_to_clean(querystrings: List[str]):
+    for param in querystrings:
+        if re.match('^[a-zA-Z]+$',param) is not None:
+            _query_params_to_clean.add(param)
+
+def _clean_custom_request_headers(headers) -> dict:
+    headers = dict(headers)
+    for remove in _custom_request_headers_to_clean:
+        if remove in headers:
+            headers.pop(remove, None)
+    return headers
+
+def custom_reqeust_headers_to_clean(headers: List[str]):
+    for head in headers:
+        if re.match('^[a-zA-Z-]+$',head) is not None:
+            _custom_request_headers_to_clean.add(head)
 
 async def build_app(argv):
     app = aiohttp.web.Application()

--- a/tests/test_clean_queries.py
+++ b/tests/test_clean_queries.py
@@ -1,0 +1,41 @@
+import os
+
+from magicproxy import proxy
+
+
+def test_cleans_custom_queries():
+    proxy.queries_to_clean(['key'])
+    path = 'https://github.com/orthros?key=123212'
+    actual = proxy._clean_path_queries(path)
+    assert actual == 'https://github.com/orthros?'
+    
+
+def test_cleans_repeated_custom_queries():
+    proxy.queries_to_clean(['key'])
+    path = 'https://github.com/orthros?key=123212&key=asdf%0ss'
+    actual = proxy._clean_path_queries(path)
+    assert actual == 'https://github.com/orthros?'
+
+def test_cleans_bare_queries():
+    proxy.queries_to_clean(['key'])
+    path = 'https://github.com/orthros?key='
+    actual = proxy._clean_path_queries(path)
+    assert actual == 'https://github.com/orthros?'
+
+def test_cleans_repeated_bare_custom_queries():
+    proxy.queries_to_clean(['key'])
+    path = 'https://github.com/orthros?key=&key='
+    actual = proxy._clean_path_queries(path)
+    assert actual == 'https://github.com/orthros?'
+
+def test_cleans_trailing_queries():
+    proxy.queries_to_clean(['key'])
+    path = 'https://github.com/orthros?someval=&key=123212'
+    actual = proxy._clean_path_queries(path)
+    assert actual == 'https://github.com/orthros?someval=&'
+
+def test_leaves_queries_alone_if_not_set():
+    proxy._query_params_to_clean = []
+    path = 'https://github.com/orthros?someval=&key=123212'
+    actual = proxy._clean_path_queries(path)
+    assert actual == 'https://github.com/orthros?someval=&key=123212'

--- a/tests/test_custom_headers.py
+++ b/tests/test_custom_headers.py
@@ -1,0 +1,24 @@
+import os
+
+from magicproxy import proxy
+
+def test_clean_request_headers_strips_custom_headers():
+    proxy.custom_reqeust_headers_to_clean(['X-Custom-Me'])
+    headers = dict()
+    headers['X-Custom-Me'] = 'A Custom Value'
+    actual = proxy._clean_request_headers(headers)
+    assert 'X-Custom-Me' not in actual
+
+def test_strips_custom_headers():
+    proxy.custom_reqeust_headers_to_clean(['X-Custom-Me'])
+    headers = dict()
+    headers['X-Custom-Me'] = 'A Custom Value'
+    actual = proxy._clean_custom_request_headers(headers)
+    assert 'X-Custom-Me' not in actual
+
+def test_leaves_headers_alone_if_undefined():
+    proxy._custom_request_headers_to_clean = []
+    headers = dict()
+    headers['X-Custom-Me'] = 'A Custom Value'
+    actual = proxy._clean_custom_request_headers(headers)
+    assert headers == actual


### PR DESCRIPTION
Adds support for cleaning request query parameters and headers

Before calling proxy.app.run() call proxy.custom_request_headers_to_clean() with a list of strings, and
those headers will be removed from the request before being forwarded to GitHub, or call proxy.queries_to_clean() with a list of strings, and those query parameters will be removed before being forwarded to GitHub.

e.g. If "key" was one of the queries to remove: https://[magic-github-proxy-address]/theacodes/magic-github-proxy/issues?key=12345asdf would be forwarded as to https://github.com/theacodes/magic-github-proxy/issues?

Change-Id: Id5b8aa94c8e764a1a8302c48239f0bd56f5b1140